### PR TITLE
Fix anchor offset for sticky masthead

### DIFF
--- a/_sass/layout/_page.scss
+++ b/_sass/layout/_page.scss
@@ -22,6 +22,16 @@
     display: inline-block;
     width: calc(100% - 30px);
   }
+
+  /* Offset anchor targets for sticky masthead */
+  h1[id],
+  h2[id],
+  h3[id],
+  h4[id],
+  h5[id],
+  h6[id] {
+    scroll-margin-top: calc(var(--masthead-height) + 0.5rem);
+  }
 }
 
 /* 

--- a/_sass/themes/_variables.scss
+++ b/_sass/themes/_variables.scss
@@ -15,6 +15,7 @@
   --code-background: rgba(0, 0, 0, 0.2);
   --masthead-background: #121212;
   --masthead-border: rgba(42, 154, 243, 0.3);
+  --masthead-height: 64px;
   --toggle-background: #121212;
   --toggle-border: rgba(42, 154, 243, 0.5);
   
@@ -35,6 +36,7 @@
   --code-background: rgba(0, 0, 0, 0.05);
   --masthead-background: #ffffff;
   --masthead-border: rgba(0, 0, 0, 0.1);
+  --masthead-height: 64px;
   --toggle-background: #f8f9fa;
   --toggle-border: rgba(0, 102, 214, 0.5);
 }


### PR DESCRIPTION
## Summary
- define `--masthead-height` CSS variable for both themes
- apply `scroll-margin-top` to headings so anchor links aren't hidden

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: Could not find nokogiri)*

------
https://chatgpt.com/codex/tasks/task_e_6844e9e558048320ba6a68c236607450