### PR TITLE
Fix navigation overshoot

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -43,6 +43,9 @@
 <!-- Resume handler script - added defer attribute -->
 <script src="{{ '/assets/js/resume-handler.js' | relative_url }}" defer></script>
 
+<!-- Adjust masthead offset dynamically -->
+<script src="{{ '/assets/js/masthead-offset.js' | relative_url }}" defer></script>
+
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" media="print" onload="this.media='all'">
 <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"></noscript>
 

--- a/_sass/layout/_page.scss
+++ b/_sass/layout/_page.scss
@@ -22,6 +22,16 @@
     display: inline-block;
     width: calc(100% - 30px);
   }
+
+  /* Offset anchor targets for sticky masthead */
+  h1[id],
+  h2[id],
+  h3[id],
+  h4[id],
+  h5[id],
+  h6[id] {
+    scroll-margin-top: calc(var(--masthead-height) + 0.5rem);
+  }
 }
 
 /* 

--- a/_sass/themes/_variables.scss
+++ b/_sass/themes/_variables.scss
@@ -15,6 +15,7 @@
   --code-background: rgba(0, 0, 0, 0.2);
   --masthead-background: #121212;
   --masthead-border: rgba(42, 154, 243, 0.3);
+  --masthead-height: 64px;
   --toggle-background: #121212;
   --toggle-border: rgba(42, 154, 243, 0.5);
   
@@ -35,6 +36,7 @@
   --code-background: rgba(0, 0, 0, 0.05);
   --masthead-background: #ffffff;
   --masthead-border: rgba(0, 0, 0, 0.1);
+  --masthead-height: 64px;
   --toggle-background: #f8f9fa;
   --toggle-border: rgba(0, 102, 214, 0.5);
 }

--- a/assets/js/masthead-offset.js
+++ b/assets/js/masthead-offset.js
@@ -1,0 +1,11 @@
+// Adjust the CSS variable for masthead height based on actual element size
+function updateMastheadOffset() {
+  const masthead = document.querySelector('.masthead');
+  if (!masthead) return;
+  const height = masthead.getBoundingClientRect().height;
+  document.documentElement.style.setProperty('--masthead-height', `${height}px`);
+}
+
+// Update on load and when window resizes
+window.addEventListener('DOMContentLoaded', updateMastheadOffset);
+window.addEventListener('resize', updateMastheadOffset);


### PR DESCRIPTION
## Summary
- add a JavaScript utility to set a `--masthead-height` CSS variable dynamically
- load new script in the custom head

## Testing
- `bundle install` *(fails: RubyZip warnings but installs)*
- `bundle exec jekyll build` *(fails: Could not find nokogiri gem)*

------
https://chatgpt.com/codex/tasks/task_e_6844e9e558048320ba6a68c236607450